### PR TITLE
pluck: Remove some code for removed data types

### DIFF
--- a/docs/scrapyd.rst
+++ b/docs/scrapyd.rst
@@ -120,3 +120,9 @@ To :ref:`use an HTTP and/or HTTPS proxy<proxy>`, `use <https://scrapyd.readthedo
 .. note::
 
    The ``http_proxy`` and/or ``https_proxy`` environment variables must already be set in Scrapyd's environment on the remote server.
+
+If the crawl's log file contains HTTP 429 Too Many Requests errors, you can make the spider wait between requests by setting the `DOWNLOAD_DELAY <https://docs.scrapy.org/en/latest/topics/settings.html#download-delay>`__ setting (in seconds):
+
+.. code-block:: bash
+
+   curl http://localhost:6800/schedule.json -d project=kingfisher -d spider=spider_name -d setting=DOWNLOAD_DELAY=1

--- a/kingfisher_scrapy/pipelines.py
+++ b/kingfisher_scrapy/pipelines.py
@@ -80,28 +80,28 @@ class Pluck:
         if not spider.pluck:
             return item
 
+        if isinstance(item['data'], dict):
+            data = item
+        else:
+            data = json.loads(item['data'])
+
         value = None
         if spider.package_pointer:
-            try:
-                package = _get_package(item)
-            except NotImplementedError as e:
-                value = f'error: {e}'
-            else:
-                value = _resolve_pointer(package, spider.package_pointer)
+            value = _resolve_pointer(data, spider.package_pointer)
         else:  # spider.release_pointer
-            if item['data_type'] in ('release_package', 'release'):
-                data = _get_releases(item)
-                if data:
-                    value = max(_resolve_pointer(r, spider.release_pointer) for r in data)
-            elif item['data_type'] in ('record_package', 'record'):
-                data = _get_records(item)
-                if data:
+            if item['data_type'].startswith('release'):
+                releases = data['releases']
+                if releases:
+                    value = max(_resolve_pointer(r, spider.release_pointer) for r in releases)
+            elif item['data_type'].startswith('record'):
+                records = data['records']
+                if records:
                     # This assumes that the first record in the record package has the desired value.
-                    data = data[0]
-                    if 'releases' in data:
-                        value = max(_resolve_pointer(r, spider.release_pointer) for r in data['releases'])
-                    elif 'compiledRelease' in data:
-                        value = _resolve_pointer(data['compiledRelease'], spider.release_pointer)
+                    record = records[0]
+                    if 'releases' in record:
+                        value = max(_resolve_pointer(r, spider.release_pointer) for r in record['releases'])
+                    elif 'compiledRelease' in record:
+                        value = _resolve_pointer(record['compiledRelease'], spider.release_pointer)
 
         if value and spider.truncate:
             value = value[:spider.truncate]
@@ -165,34 +165,3 @@ def _resolve_pointer(data, pointer):
         return jsonpointer.resolve_pointer(data, pointer)
     except jsonpointer.JsonPointerException:
         return f'error: {pointer} not found'
-
-
-def _get_package(item):
-    data = json.loads(item['data'])
-
-    if item['data_type'] in ('release_package', 'record_package'):
-        return data
-
-    raise NotImplementedError(f"no package for data_type: {item['data_type']}")
-
-
-def _get_releases(item):
-    data = json.loads(item['data'])
-
-    if item['data_type'] == 'release_package':
-        return data['releases']
-    elif item['data_type'] == 'release':
-        return [data]
-
-    raise NotImplementedError(f"unhandled data_type: {item['data_type']}")
-
-
-def _get_records(item):
-    data = json.loads(item['data'])
-
-    if item['data_type'] == 'record_package':
-        return data['records']
-    elif item['data_type'] == 'record':
-        return [data]
-
-    raise NotImplementedError(f"unhandled data_type: {item['data_type']}")

--- a/kingfisher_scrapy/pipelines.py
+++ b/kingfisher_scrapy/pipelines.py
@@ -89,13 +89,11 @@ class Pluck:
             else:
                 value = _resolve_pointer(package, spider.package_pointer)
         else:  # spider.release_pointer
-            if item['data_type'] in ('release_package', 'release_package_list', 'release_package_list_in_results',
-                                     'release_list', 'release'):
+            if item['data_type'] in ('release_package', 'release'):
                 data = _get_releases(item)
                 if data:
                     value = max(_resolve_pointer(r, spider.release_pointer) for r in data)
-            elif item['data_type'] in ('record_package', 'record_package_list', 'record_package_list_in_results',
-                                       'record'):
+            elif item['data_type'] in ('record_package', 'record'):
                 data = _get_records(item)
                 if data:
                     # This assumes that the first record in the record package has the desired value.
@@ -174,11 +172,6 @@ def _get_package(item):
 
     if item['data_type'] in ('release_package', 'record_package'):
         return data
-    # This assumes that the first package in the list has the desired value.
-    elif item['data_type'] in ('release_package_list', 'record_package_list'):
-        return data[0]
-    elif item['data_type'] in ('release_package_list_in_results', 'record_package_list_in_results'):
-        return data['results'][0]
 
     raise NotImplementedError(f"no package for data_type: {item['data_type']}")
 
@@ -188,13 +181,6 @@ def _get_releases(item):
 
     if item['data_type'] == 'release_package':
         return data['releases']
-    # This assumes that the first package in the list has the desired value.
-    elif item['data_type'] == 'release_package_list':
-        return data[0]['releases']
-    elif item['data_type'] == 'release_package_list_in_results':
-        return data['results'][0]['releases']
-    elif item['data_type'] == 'release_list':
-        return data
     elif item['data_type'] == 'release':
         return [data]
 
@@ -206,11 +192,6 @@ def _get_records(item):
 
     if item['data_type'] == 'record_package':
         return data['records']
-    # This assumes that the first package in the list has the desired value.
-    elif item['data_type'] == 'record_package_list':
-        return data[0]['records']
-    elif item['data_type'] == 'record_package_list_in_results':
-        return data['results'][0]['records']
     elif item['data_type'] == 'record':
         return [data]
 

--- a/tests/pipelines/test_pluck.py
+++ b/tests/pipelines/test_pluck.py
@@ -27,10 +27,10 @@ package_parameters = [
 ]
 release_parameters = package_parameters + [
     # Releases
-    ('release', release_package['releases'][1]),
+    ('release', {'releases': [release_package['releases'][1]]}),
     # Records
-    ('record', record_package['records'][0]),
-    ('record', {'compiledRelease': release_package['releases'][1]}),
+    ('record', {'records': [record_package['records'][0]]}),
+    ('record', {'records': [{'compiledRelease': release_package['releases'][1]}]}),
 ]
 
 
@@ -112,4 +112,4 @@ def test_process_item_non_package_data_type():
         'url': 'http://test.com',
     })
 
-    assert pipeline.process_item(item, spider) == PluckedItem({'value': 'error: no package for data_type: release'})
+    assert pipeline.process_item(item, spider) == PluckedItem({'value': 'error: /publishedDate not found'})

--- a/tests/pipelines/test_pluck.py
+++ b/tests/pipelines/test_pluck.py
@@ -22,12 +22,8 @@ record_package = {
 package_parameters = [
     # Releases
     ('release_package', release_package),
-    ('release_package_list', [release_package]),
-    ('release_package_list_in_results', {'results': [release_package]}),
     # Records
     ('record_package', record_package),
-    ('record_package_list', [record_package]),
-    ('record_package_list_in_results', {'results': [record_package]}),
 ]
 release_parameters = package_parameters + [
     # Releases


### PR DESCRIPTION
While looking at the use of str/bytes/json.load/json.dump, I noticed the Pluck command still referenced old data types. I think some more cleanup can be done. I only did the easy and obvious so far.