### PR TITLE
tests: Update some tests using old data types

### DIFF
--- a/tests/pipelines/test_unflatten.py
+++ b/tests/pipelines/test_unflatten.py
@@ -14,7 +14,7 @@ def test_process_item_csv():
     item = File({
         'file_name': 'test.csv',
         'data': b'data',
-        'data_type': 'release_list',
+        'data_type': 'release_package',
         'url': 'http://test.com/test.csv',
     })
 
@@ -27,7 +27,7 @@ def test_process_item_xlsx():
     item = File({
         'file_name': 'test.xlsx',
         'data': save_virtual_workbook(Workbook()),
-        'data_type': 'release_list',
+        'data_type': 'release_package',
         'url': 'http://test.com/test.xlsx',
     })
 
@@ -40,7 +40,7 @@ def test_process_item_extension_error():
     item = File({
         'file_name': 'file',
         'data': b'data',
-        'data_type': 'release_list',
+        'data_type': 'release_package',
         'url': 'http://test.com/file',
     })
 
@@ -54,7 +54,7 @@ def test_process_item_xlsx_error():
     item = File({
         'file_name': 'test.xlsx',
         'data': b'data',
-        'data_type': 'release_list',
+        'data_type': 'release_package',
         'url': 'http://test.com/test.xlsx',
     })
 

--- a/tests/test_index_spider.py
+++ b/tests/test_index_spider.py
@@ -13,46 +13,46 @@ from . import spider_with_crawler
 TEST_CASES = [
     # honduras_portal_*
     ({
-        'total_pages_pointer': '/results',
         'data_type': 'release_package',
-        'formatter': staticmethod(parameters('page'))
+        'total_pages_pointer': '/results',
+        'formatter': staticmethod(parameters('page')),
     }, '{"results": 10}', 'http://example.com', r'http://example\.com\?page=(\d+)',
         [str(x) for x in range(2, 11)]),
     ({
-        'total_pages_pointer': '/results',
-        'page_size': '50',
         'data_type': 'release_package',
+        'total_pages_pointer': '/results',
         'formatter': staticmethod(parameters('page')),
-        'additional_params': {'pageSize': 10}
+        'page_size': '50',
+        'additional_params': {'pageSize': 10},
     }, '{"results": 10}', 'http://example.com', r'http://example\.com\?page=(\d+)&pageSize=10',
         [str(x) for x in range(2, 11)]),
     # mexico_administracion_publica_federal
     ({
+        'data_type': 'release_package',
         'count_pointer': '/total',
         'limit': '/limit',
-        'data_type': 'release_package',
         'use_page': True,
-        'formatter': staticmethod(parameters('page'))
+        'formatter': staticmethod(parameters('page')),
     }, '{"total": 50, "limit": 10}', 'http://example.com', r'http://example\.com\?page=(\d+)',
         [str(x) for x in range(2, 6)]),
     # canada_montreal
     ({
+        'data_type': 'release_package',
         'count_pointer': '/total',
         'limit': 10,
-        'data_type': 'release_package',
-        'formatter': staticmethod(parameters('offset'))
+        'formatter': staticmethod(parameters('offset')),
     }, '{"total": 50}', 'http://example.com', r'http://example\.com\?limit=10&offset=(\d+)',
         [str(x) for x in range(10, 50, 10)]),
     # kenya_makueni
     ({
+        'data_type': 'release_package',
+        'formatter': staticmethod(parameters('pageNumber')),
+        'param_page': 'pageNumber',
+        'additional_params': {'step': 10},
         'yield_list_results': False,
+        'base_url': 'http://example.com/ocds',
         'range_generator': lambda _self, data, response: range(ceil(int(response.text) / 10)),
         'url_builder': lambda _self, value, data, response: _self.pages_url_builder(value, data, response),
-        'additional_params': {'step': 10},
-        'param_page': 'pageNumber',
-        'data_type': 'release_package_list',
-        'formatter': staticmethod(parameters('pageNumber')),
-        'base_url': 'http://example.com/ocds'
     }, '100', 'http://example.com', r'http://example\.com/ocds\?pageNumber=(\d+)&step=10',
         [str(x) for x in range(0, 10)])
 ]

--- a/tests/test_index_spider.py
+++ b/tests/test_index_spider.py
@@ -22,7 +22,6 @@ TEST_CASES = [
         'data_type': 'release_package',
         'total_pages_pointer': '/results',
         'formatter': staticmethod(parameters('page')),
-        'page_size': '50',
         'additional_params': {'pageSize': 10},
     }, '{"results": 10}', 'http://example.com', r'http://example\.com\?page=(\d+)&pageSize=10',
         [str(x) for x in range(2, 11)]),

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
 import pytest
 
-from kingfisher_scrapy.util import get_parameter_value, replace_parameters
+from kingfisher_scrapy.util import get_parameter_value, replace_parameters, join, components, parameters
 
 
 @pytest.mark.parametrize('url,value,expected', [
@@ -20,3 +20,11 @@ def test_replace_parameters(url, value, expected):
 ])
 def test_get_parameter_value(url, expected):
     assert get_parameter_value(url, 'page') == expected
+
+
+@pytest.mark.parametrize('url,extension,expected', [
+    ('http://example.com/api/planning.json?page=1', None, 'planning-page-1'),
+    ('http://example.com/api/planning?page=1', 'zip', 'planning-page-1.zip'),
+])
+def test_join(url, extension, expected):
+    assert join(components(-1), parameters('page'), extension=extension)(url) == expected

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,6 @@
 import pytest
 
-from kingfisher_scrapy.util import get_parameter_value, replace_parameters, join, components, parameters
+from kingfisher_scrapy.util import components, get_parameter_value, join, parameters, replace_parameters
 
 
 @pytest.mark.parametrize('url,value,expected', [


### PR DESCRIPTION
This is complementary to #614. I wasn't sure if `test_index_spider.py` needed other updates. For example, one of the test cases uses `page_size`, but we don't define that in `base_spider`. Was `limit` intended?