### PR TITLE
extensions: KingfisherPluck: Extensions are instantiated per crawler, not globally

### DIFF
--- a/kingfisher_scrapy/extensions.py
+++ b/kingfisher_scrapy/extensions.py
@@ -20,10 +20,10 @@ class KingfisherPluck:
         self.directory = directory
         self.max_bytes = max_bytes
 
-        # The count of bytes received per spider.
-        self.bytes_received_counts = defaultdict(int)
-        # The set of spiders that have called the `item_scraped` method.
-        self.item_scraped_called = set()
+        # The number of bytes received.
+        self.total_bytes_received = 0
+        # Whether `item_scraped` has been called.
+        self.item_scraped_called = False
 
     @classmethod
     def from_crawler(cls, crawler):
@@ -43,20 +43,20 @@ class KingfisherPluck:
         if not spider.pluck or request.callback or request.meta['file_name'].endswith(('.rar', '.zip')):
             return
 
-        self.bytes_received_counts[spider.name] += len(data)
-        if self.bytes_received_counts[spider.name] >= self.max_bytes:
+        self.total_bytes_received += len(data)
+        if self.total_bytes_received >= self.max_bytes:
             raise StopDownload(fail=False)
 
     def item_scraped(self, item, spider):
-        if not spider.pluck or spider.name in self.item_scraped_called or not isinstance(item, PluckedItem):
+        if not spider.pluck or self.item_scraped_called or not isinstance(item, PluckedItem):
             return
 
-        self.item_scraped_called.add(spider.name)
+        self.item_scraped_called = True
 
         self._write(spider, item['value'])
 
     def spider_closed(self, spider, reason):
-        if not spider.pluck or spider.name in self.item_scraped_called:
+        if not spider.pluck or self.item_scraped_called:
             return
 
         self._write(spider, f'closed: {reason}')

--- a/kingfisher_scrapy/extensions.py
+++ b/kingfisher_scrapy/extensions.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-from collections import defaultdict
 
 import sentry_sdk
 from scrapy import signals

--- a/tests/extensions/test_kingfisher_pluck.py
+++ b/tests/extensions/test_kingfisher_pluck.py
@@ -40,14 +40,6 @@ def test_item_scraped():
         with open(os.path.join(tmpdirname, 'pluck-release-date.csv')) as f:
             assert '2020-10-01,test\n' == f.read()
 
-        # An item from another spider is appended.
-        spider.name = 'other'
-        item['value'] = '2020-10-02'
-        extension.item_scraped(item, spider)
-
-        with open(os.path.join(tmpdirname, 'pluck-release-date.csv')) as f:
-            assert '2020-10-01,test\n2020-10-02,other\n' == f.read()
-
 
 def test_spider_closed_with_items():
     with TemporaryDirectory() as tmpdirname:

--- a/tests/extensions/test_kingfisher_pluck.py
+++ b/tests/extensions/test_kingfisher_pluck.py
@@ -95,7 +95,7 @@ def test_bytes_received_dont_stop_download():
 
         extension.bytes_received(data=b'12345', spider=spider, request=request)
 
-        assert extension.bytes_received_counts[spider.name] == 5
+        assert extension.total_bytes_received == 5
         assert extension.max_bytes == 10
 
 
@@ -112,4 +112,4 @@ def test_bytes_received_ignored_requests(test_request):
 
         extension.bytes_received(data=b'12345', spider=spider, request=test_request)
 
-        assert extension.bytes_received_counts[spider.name] == 0
+        assert extension.total_bytes_received == 0


### PR DESCRIPTION
I think the logic of checking which spiders have yielded items was introduced in https://github.com/open-contracting/kingfisher-collect/commit/e2e999d00ca5b936071482ae8a303a9037ae183f