### PR TITLE
AddPackageMiddleware: add spider declared version to basic package

### DIFF
--- a/kingfisher_scrapy/middlewares.py
+++ b/kingfisher_scrapy/middlewares.py
@@ -204,7 +204,7 @@ class AddPackageMiddleware:
                 key = 'releases'
             else:
                 key = 'records'
-            item['data'] = {key: [data]}
+            item['data'] = {key: [data], 'version': spider.ocds_version}
             item['data_type'] += '_package'
 
             yield item

--- a/tests/middlewares/test_kingfisher_transform_middleware.py
+++ b/tests/middlewares/test_kingfisher_transform_middleware.py
@@ -84,7 +84,7 @@ def test_data_types(data_type, data, root_path):
         expected['data'] = {f"{data_type[:-8]}s": [{"ocid": "abc"}], "uri": "test"}
         expected['data_type'] = data_type
     else:
-        expected['data'] = {f"{data_type}s": [{"ocid": "abc"}]}
+        expected['data'] = {f"{data_type}s": [{"ocid": "abc"}], "version": spider.ocds_version}
         expected['data_type'] = f'{data_type}_package'
 
     assert item == expected


### PR DESCRIPTION
I think that we can add the spiders's declared version to the basic package as well so we don't need to transform the packages from 1.0 to 1.1 in Kingfisher Process if the releases are already in the latest version of the standard