### PR TITLE
kingfisher-process: Send OCDS version

### DIFF
--- a/kingfisher_scrapy/extensions.py
+++ b/kingfisher_scrapy/extensions.py
@@ -263,7 +263,8 @@ class KingfisherProcessAPI:
         data = {
             'collection_source': spider.name,
             'collection_data_version': spider.get_start_time('%Y-%m-%d %H:%M:%S'),
-            'collection_sample': str(bool(spider.sample))
+            'collection_sample': str(bool(spider.sample)),
+            'collection_ocds_version': spider.ocds_version,
         }
         if file_name:
             data['file_name'] = file_name

--- a/tests/extensions/test_kingfisher_process_api.py
+++ b/tests/extensions/test_kingfisher_process_api.py
@@ -87,6 +87,7 @@ def test_item_scraped_file(sample, is_sample, path, note, encoding, encoding2, d
             'collection_source': 'test',
             'collection_data_version': '2001-02-03 04:05:06',
             'collection_sample': str(is_sample),
+            'collection_ocds_version': '1.1',
             'file_name': 'file.json',
             'url': 'https://example.com/remote.json',
             # Specific to File.
@@ -150,6 +151,7 @@ def test_item_scraped_file_item(sample, is_sample, note, encoding, ok, tmpdir, c
             'collection_source': 'test',
             'collection_data_version': '2001-02-03 04:05:06',
             'collection_sample': str(is_sample),
+            'collection_ocds_version': '1.1',
             'file_name': 'data.json',
             'url': 'https://example.com/remote.json',
             # Specific to FileItem.
@@ -201,6 +203,7 @@ def test_item_scraped_file_error(sample, is_sample, ok, tmpdir, caplog):
             'collection_source': 'test',
             'collection_data_version': '2001-02-03 04:05:06',
             'collection_sample': str(is_sample),
+            'collection_ocds_version': '1.1',
             'file_name': 'file.json',
             'url': 'https://example.com/remote.json',
             # Specific to FileError.
@@ -247,6 +250,7 @@ def test_item_error(sample, is_sample, ok, tmpdir, caplog):
             'collection_source': 'test',
             'collection_data_version': '2001-02-03 04:05:06',
             'collection_sample': str(is_sample),
+            'collection_ocds_version': '1.1',
             'file_name': 'file.json',
             'url': 'https://example.com/remote.json',
             # Specific to FileError.
@@ -287,6 +291,7 @@ def test_spider_closed(sample, is_sample, ok, tmpdir, caplog):
             'collection_source': 'test',
             'collection_data_version': '2001-02-03 04:05:06',
             'collection_sample': str(is_sample),
+            'collection_ocds_version': '1.1',
         }
 
         assert data['method'] == 'POST'
@@ -347,6 +352,7 @@ def test_spider_error(sample, is_sample, ok, tmpdir, caplog):
             'collection_source': 'test',
             'collection_data_version': '2001-02-03 04:05:06',
             'collection_sample': str(is_sample),
+            'collection_ocds_version': '1.1',
             'file_name': 'https://example.com/remote.json',
             'url': 'https://example.com/remote.json',
             # Specific to FileError.


### PR DESCRIPTION
I deployed a quick fix to the old Process to skip the upgrade if the OCDS version is 1.1. This should make processing faster until we have the new Process. Goes with https://github.com/open-contracting/kingfisher-process/commit/809f5e8ae2d10a5d0009c0f080ab0af8e5fa9e50