### PR TITLE
update nigeria cross river spider

### DIFF
--- a/kingfisher_scrapy/spiders/nigeria_cross_river_base.py
+++ b/kingfisher_scrapy/spiders/nigeria_cross_river_base.py
@@ -1,16 +1,38 @@
 from abc import abstractmethod
+from datetime import datetime
 
-from kingfisher_scrapy.base_spider import PeriodicSpider
-from kingfisher_scrapy.util import components, join, parameters
+import scrapy
+
+from kingfisher_scrapy.base_spider import SimpleSpider
+from kingfisher_scrapy.util import components, handle_http_error, join, parameters
 
 
-class NigeriaCrossRiverBase(PeriodicSpider):
+class NigeriaCrossRiverBase(SimpleSpider):
     # SimpleSpider
     base_url = 'http://ocdsapi.dppib-crsgov.org/api/ocdsAPI/'
 
     # BaseSpider
     date_format = 'year-month'
-    default_from_date = '2020-02'
+
+    def start_requests(self):
+        url = 'http://ocds.dppib-crsgov.org/Login.aspx?ReturnUrl=%2fReleasePackageViewModel_ListView%2f'
+        yield scrapy.Request(url,
+                             meta={'page': 0},
+                             callback=self.parse_date_list)
+
+    @handle_http_error
+    def parse_date_list(self, response):
+        # pagination handler
+        # page = response.request.meta['page']
+        # available_page_list = [re.findall(r"'(.+?)',?", x) for x in
+        #                       response.xpath('//a[starts-with(@class,"dxp-num")]/@onclick').extract()]
+
+        available_date_list = [datetime.strptime(date.split('T')[0], '%Y-%m-%d') for date in
+                               response.xpath('//tr[@class="dxgvDataRow_XafTheme"]/td[6]/text()').extract()]
+
+        for date in available_date_list:
+            for number, url in enumerate(self.build_urls(date)):
+                yield self.build_request(url, self.get_formatter(), priority=number * -1)
 
     def get_formatter(self):
         return join(components(-1), parameters('year', 'month'))


### PR DESCRIPTION
I’m working to try to get the dates and see how we can simulated click on future pages using the form from the nigeria cross river publication data site, currently, [the website](http://ocds.dppib-crsgov.org/ReleasePackageViewModel_ListView/) is up but has a data load problem, [the API request method](https://github.com/open-contracting/kingfisher-collect/issues/766#issuecomment-890683395) doesn't work.

The site doesn't use these inputs for the pagination:
```
__EVENTTARGET
__EVENTARGUMENT
```

The pagination work with the javascript onclick function: `ASPx.GVPagerOnClick('...','PN<page-number>')`
I think we can scrape this with the[ selenium module](https://selenium-python.readthedocs.io/waits.html) for future pages.

With this update, we can scrape the dates and request them. Ref #775