### PR TITLE
scrapy config: use GIT revision as scrapyd version

### DIFF
--- a/scrapy.cfg
+++ b/scrapy.cfg
@@ -1,2 +1,4 @@
 [settings]
 default = kingfisher_scrapy.settings
+[deploy:kingfisher]
+version = GIT


### PR DESCRIPTION
closes #802 

I deployed the `main` branch with this config and the output was:

``` bash
$ scrapyd-deploy kingfisher
Packing version v0.95-245-g6f2d66b-main
Deploying to project "kingfisher" in https://collect.kingfisher.open-contracting.org/addversion.json
Server response (200):
{"node_name": "ocp04", "status": "ok", "project": "kingfisher", "version": "v0.95-245-g6f2d66b-main", "spiders": 131}
```
