### PR TITLE
Docs updates

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,4 +8,3 @@ python:
     - requirements: docs/requirements.txt
 sphinx:
   fail_on_warning: true
-  

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,3 +6,6 @@ build:
 python:
   install:
     - requirements: docs/requirements.txt
+sphinx:
+  fail_on_warning: true
+  

--- a/docs/spiders.rst
+++ b/docs/spiders.rst
@@ -87,10 +87,7 @@ All spiders support these arguments:
      - string
    * - ``qs:*``
      - Query string parameters to append to each URL, for example: ``qs:parameter1=value1``. See also: :ref:`filter`.
-
-..
-   If you add or rename a spider argument, remember to update `ScrapyLogFile.is_complete()` in:
-   https://github.com/open-contracting/kingfisher-archive/blob/main/ocdskingfisherarchive/scrapy_log_file.py
+     - string
 
 Some spiders support these arguments:
 


### PR DESCRIPTION
The spiders' arguments table was missing one column at the last row, generating this warning when building the docs:

`/docs/spiders.rst:75: WARNING: Error parsing content block for the "list-table" directive: uniform two-level bullet list expected, but row 4 does not contain the same number of items as row 1 (2 vs 3).`

I also removed the reference to the kingfisher-archive process as it has been archived.