### PR TITLE
Add SpiderInitializationError base class

### DIFF
--- a/kingfisher_scrapy/commands/checkall.py
+++ b/kingfisher_scrapy/commands/checkall.py
@@ -4,6 +4,7 @@ import re
 from textwrap import dedent
 
 from scrapy.commands import ScrapyCommand
+from scrapy.exceptions import NotSupported
 from scrapy.utils.misc import walk_modules
 from scrapy.utils.spider import iter_spider_classes
 
@@ -193,7 +194,7 @@ class Checker:
                 period = 'year'
                 format_ = 'YYYY'
             else:
-                raise NotImplementedError(f'checkall: date_format "{self.cls.date_format}" not implemented')
+                raise NotSupported(f'checkall: date_format "{self.cls.date_format}" not implemented')
 
             expected = format_string.format(period=period, format=format_, default=default(self.cls))
             if spider_arguments[spider_argument] != expected:

--- a/kingfisher_scrapy/exceptions.py
+++ b/kingfisher_scrapy/exceptions.py
@@ -1,9 +1,11 @@
+import logging
+import traceback
+
+logger = logging.getLogger(__name__)
+
+
 class KingfisherScrapyError(Exception):
     """Base class for exceptions from within this application"""
-
-
-class SpiderArgumentError(KingfisherScrapyError):
-    """Raised when a spider argument's value is invalid"""
 
 
 class MissingEnvVarError(KingfisherScrapyError):
@@ -22,5 +24,16 @@ class UnknownArchiveFormatError(KingfisherScrapyError):
     """Raised when the archive format of a file can't be determined from the filename"""
 
 
-class IncoherentConfigurationError(KingfisherScrapyError):
-    """Raised when a spider is misconfigured by a developer"""
+class SpiderInitializationError(KingfisherScrapyError):
+    """Base class for exceptions that occur before a spider is initialized"""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        logger.error('%s\n%s', str(self), traceback.format_stack()[-2].rstrip())
+
+
+class SpiderArgumentError(SpiderInitializationError):
+    """Raised when a spider argument's value is invalid, from its from_crawler class method"""
+
+
+class IncoherentConfigurationError(SpiderInitializationError):
+    """Raised when a spider is misconfigured by a developer, from its __init__ method"""

--- a/tests/spiders/error.py
+++ b/tests/spiders/error.py
@@ -1,0 +1,46 @@
+"""
+This spider raises exceptions in different methods. You can use this to test whether exceptions are logged properly.
+
+.. code-block:: bash
+
+   python -m scrapy crawl error -s SPIDER_MODULES=tests.spiders
+"""
+import scrapy
+
+from kingfisher_scrapy.base_spider import BaseSpider
+from kingfisher_scrapy.exceptions import SpiderArgumentError
+
+
+class Error(BaseSpider):
+    name = 'error'
+
+    def __init__(self, raise_from_crawler=False, raise_init=False, raise_start_requests=False, raise_parse=False,
+                 *args, **kwargs):
+        super().__init__(*args, raise_from_crawler=raise_from_crawler, raise_init=raise_init,
+                         raise_start_requests=raise_start_requests, raise_parse=raise_parse, **kwargs)
+
+        self.raise_from_crawler = raise_from_crawler
+        self.raise_init = raise_init
+        self.raise_start_requests = raise_start_requests
+        self.raise_parse = raise_parse
+
+        if raise_init:
+            raise IncoherentConfigurationError("message")
+
+    @classmethod
+    def from_crawler(cls, crawler, *args, **kwargs):
+        spider = super(BaseSpider, cls).from_crawler(crawler, *args, **kwargs)
+
+        if spider.raise_from_crawler:
+            raise SpiderArgumentError("message")
+
+        return spider
+
+    def start_requests(self):
+        if self.raise_start_requests:
+            raise Exception("message")
+        yield scrapy.Request('http://httpstat.us/200')
+
+    def parse(self, response):
+        if self.raise_parse:
+            raise Exception("message")

--- a/tests/spiders/error.py
+++ b/tests/spiders/error.py
@@ -8,7 +8,7 @@ This spider raises exceptions in different methods. You can use this to test whe
 import scrapy
 
 from kingfisher_scrapy.base_spider import BaseSpider
-from kingfisher_scrapy.exceptions import SpiderArgumentError
+from kingfisher_scrapy.exceptions import IncoherentConfigurationError, SpiderArgumentError
 
 
 class Error(BaseSpider):

--- a/tests/spiders/fail.py
+++ b/tests/spiders/fail.py
@@ -1,5 +1,9 @@
 """
 This spider deliberately generates HTTP errors. You can use this to test whether errors are recorded properly.
+
+.. code-block:: bash
+
+   python -m scrapy crawl fail -s SPIDER_MODULES=tests.spiders
 """
 import scrapy
 
@@ -8,9 +12,6 @@ from kingfisher_scrapy.base_spider import SimpleSpider
 
 class Fail(SimpleSpider):
     name = 'fail'
-
-    # BaseSpider
-    skip_pluck = 'Not a real spider'
 
     # SimpleSpider
     data_type = 'release_package'


### PR DESCRIPTION
```
python -m scrapy crawl error -s SPIDER_MODULES=tests.spiders -a raise_from_crawler=True

...

2021-11-24 13:56:06 [error] INFO: Spider arguments: {'sample': None, 'note': None, 'from_date': None, 'until_date': None, 'crawl_time': None, 'keep_collection_open': None, 'package_pointer': None, 'release_pointer': None, 'truncate': None, 'compile_releases': None, 'raise_from_crawler': 'True', 'raise_init': False, 'raise_start_requests': False, 'raise_parse': False}
2021-11-24 13:56:06 [kingfisher_scrapy.exceptions] ERROR: message
  File "/Users/james/Sites/remote/open-contracting/kingfisher-collect/tests/spiders/error.py", line 35, in from_crawler
    raise SpiderArgumentError("message")
```
