### PR TITLE
database_store_extension: support compiling from list of releases from records

### DIFF
--- a/kingfisher_scrapy/base_spider.py
+++ b/kingfisher_scrapy/base_spider.py
@@ -208,8 +208,6 @@ class BaseSpider(scrapy.Spider):
         if crawler.settings['DATABASE_URL']:
             if not spider.crawl_time:
                 raise SpiderArgumentError("spider argument `crawl_time`: can't be blank if `DATABASE_URL` is set")
-            if spider.compile_releases and 'record' in getattr(spider, 'data_type', ''):
-                raise SpiderArgumentError("spider argument `compile_releases`: can't be set if spider returns records")
 
         return spider
 

--- a/kingfisher_scrapy/extensions/database_store.py
+++ b/kingfisher_scrapy/extensions/database_store.py
@@ -25,11 +25,14 @@ class DatabaseStore:
 
     When the spider is closed, this extension reads the data written by the FilesStore extension to the crawl directory
     that matches the ``crawl_time`` spider argument. If the ``compile_releases`` spider argument is set, it creates
-    compiled releases. If the spider returns records and ``compile_releases`` is set, the extension uses
-    records.releases to generate the compile release. Records without releases or with linked releases will fail.
-    Then, it recreates the table, and inserts either the compiled releases, the individual releases
-    in release packages (if the spider returns releases), or the compiled releases in record packages (if the spider
-    returns records).
+    compiled releases, using individual releases. Then, it recreates the table, and inserts either the compiled
+    releases if the ``compile_releases`` spider argument is set, the individual releases in release packages (if the
+    spider returns releases), or the compiled releases in record packages (if the spider returns records).
+
+    .. warning::
+
+       If the ``compile_releases`` spider argument is set, spiders that return records without embedded releases are
+       not supported. If it isn't set, then spiders that return records without compiled releases are not supported.
 
     To perform incremental updates, the OCDS data in the crawl directory must not be deleted between crawls.
     """

--- a/kingfisher_scrapy/extensions/database_store.py
+++ b/kingfisher_scrapy/extensions/database_store.py
@@ -91,9 +91,9 @@ class DatabaseStore:
 
         if spider.compile_releases:
             if 'release' in spider.data_type:
-              prefix = ''
+                prefix = ''
             else:
-              prefix = 'records.item.releases.item'
+                prefix = 'records.item.releases.item'
         elif 'release' in spider.data_type:
             prefix = 'releases.item'
         else:

--- a/kingfisher_scrapy/extensions/database_store.py
+++ b/kingfisher_scrapy/extensions/database_store.py
@@ -25,9 +25,11 @@ class DatabaseStore:
 
     When the spider is closed, this extension reads the data written by the FilesStore extension to the crawl directory
     that matches the ``crawl_time`` spider argument. If the ``compile_releases`` spider argument is set, it creates
-    compiled releases. Then, it recreates the table, and inserts either the compiled releases, the individual releases
+    compiled releases. If the spider returns records and ``compile_releases`` is set, the extension uses
+    records.releases to generate the compile release. Records without releases or with linked releases will fail.
+    Then, it recreates the table, and inserts either the compiled releases, the individual releases
     in release packages (if the spider returns releases), or the compiled releases in record packages (if the spider
-    returns records). (Spiders that return records without ``compiledRelease`` fields are not supported.)
+    returns records).
 
     To perform incremental updates, the OCDS data in the crawl directory must not be deleted between crawls.
     """
@@ -88,7 +90,10 @@ class DatabaseStore:
             return
 
         if spider.compile_releases:
-            prefix = ''
+            if 'release' in spider.data_type:
+              prefix = ''
+            else:
+              prefix = 'records.item.releases.item'
         elif 'release' in spider.data_type:
             prefix = 'releases.item'
         else:

--- a/tests/extensions/test_database_store.py
+++ b/tests/extensions/test_database_store.py
@@ -79,6 +79,7 @@ def test_spider_closed_error(caplog, tmpdir):
     (b'{"releases": [{"date": "2021-05-26T10:00:00Z"}]}', 'release_package', 1, False),
     (b'{"releases": [{"ocid":"1", "date": "2021-05-26T10:00:00Z"}]}', 'release_package', None, True),
     (b'{"records": [{"compiledRelease": {"date": "2021-05-26T10:00:00Z"}}]}', 'record_package', None, False),
+    (b'{"records": [{"releases": [{"ocid":"1", "date": "2021-05-26T10:00:00Z"}]}]}', 'record_package', None, True),
 ])
 def test_spider_closed(caplog, tmpdir, data, data_type, sample, compile_releases):
     caplog.set_level(logging.INFO)
@@ -116,7 +117,10 @@ def test_spider_closed(caplog, tmpdir, data, data_type, sample, compile_releases
         assert max_date == expected_date
 
         if compile_releases:
-            prefix = 'empty'
+            if data_type == 'release_package':
+                prefix = 'empty'
+            else:
+                prefix = 'records.item.releases.item'
         elif data_type == 'release_package':
             prefix = 'releases.item'
         else:


### PR DESCRIPTION
This change is needed for Chile. Their records endpoint returns records with compile releases. However, some of them are incomplete, for example, https://apis.mercadopublico.cl/OCDS/data/record/4019-414-AG21
But they return the complete releases within the releases array, so we can compile the current data we have by using the release list from the records (we could also just use their releases endpoint instead, but if we do so, we will need to download all their data again)