### PR TITLE
ecuador_sercop_bulk: avoid losing data in kingfisher process

### DIFF
--- a/kingfisher_scrapy/spiders/ecuador_sercop_bulk.py
+++ b/kingfisher_scrapy/spiders/ecuador_sercop_bulk.py
@@ -43,7 +43,7 @@ class EcuadorSERCOPBulk(CompressedFileSpider, PeriodicSpider):
         data = item['data']
         package = {}
         # The file is a JSON array of release packages that we rearrange in a single package to avoid losing data
-        # in Kingfisher Process https://github.com/open-contracting/kingfisher-process/issues/353.
+        # in kingfisher-process-v1
         for number, obj in enumerate(util.transcode(self, ijson.items, data, 'item'), 1):
             if not package:
                 package = obj


### PR DESCRIPTION
Following from #940
The API is too slow, so this is a workaround to get all the data until kingfisher process is able to process a lot of file items simultaneously.