### PR TITLE
spiders: add south_africa_national_trasury_api

### DIFF
--- a/docs/spiders.rst
+++ b/docs/spiders.rst
@@ -1173,6 +1173,16 @@ Slovenia
 
    scrapy crawl slovenia_digiwhist
 
+South Africa
+~~~~~~~~~~~~
+
+.. autoclass:: kingfisher_scrapy.spiders.south_africa_national_treasury_api.SouthAfricaNationalTreasuryAPI
+   :no-members:
+
+.. code-block:: bash
+
+   scrapy crawl south_africa_national_treasury_api
+
 Spain
 ~~~~~
 

--- a/kingfisher_scrapy/commands/updatedocs.py
+++ b/kingfisher_scrapy/commands/updatedocs.py
@@ -17,7 +17,8 @@ class UpdateDocs(ScrapyCommand):
 
         def _keyfunc(module):
             module_name = module.__name__.rsplit('.', 1)[-1]
-            if module_name.startswith(('costa_rica', 'czech_republic', 'dominican_republic', 'united_kingdom')):
+            if module_name.startswith(('costa_rica', 'czech_republic', 'dominican_republic', 'south_africa',
+                                       'united_kingdom')):
                 return '_'.join(module_name.split('_', 2)[:2])
             return module_name.split('_', 1)[0]
 

--- a/kingfisher_scrapy/spiders/south_africa_national_treasury_api.py
+++ b/kingfisher_scrapy/spiders/south_africa_national_treasury_api.py
@@ -1,0 +1,34 @@
+import scrapy
+
+from kingfisher_scrapy.base_spiders import LinksSpider
+from kingfisher_scrapy.util import parameters
+
+
+class SouthAfricaNationalTreasuryAPI(LinksSpider):
+    """
+    Domain
+      South Africa National Treasury
+    Spider arguments
+      from_date
+        Download only data from this date onward (YYYY-MM-DD format). Defaults to '2021-05-01'.
+      until_date
+        Download only data until this date (YYYY-MM-DD format). Defaults to today.
+    Swagger API documentation
+      https://ocds-api.etenders.gov.za/swagger/index.html
+    """
+    name = 'south_africa_national_treasury_api'
+
+    # BaseSpider
+    date_format = 'date'
+    date_required = True
+    default_from_date = '2021-05-01'
+
+    # SimpleSpider
+    data_type = 'release_package'
+
+    # LinksSpider
+    formatter = staticmethod(parameters('PageNumber'))
+
+    def start_requests(self):
+        yield scrapy.Request('https://ocds-api.etenders.gov.za/api/OCDSReleases?PageNumber=1&PageSize=50&'
+                             f'dateFrom={self.from_date}&dateTo={self.until_date}', meta={'file_name': 'start.json'})


### PR DESCRIPTION
closes #980 

Note that I suffixed the spider with `_api` as maybe this bulk download site will work in the future https://data.etenders.gov.za/Home/ReleasesFiles