### PR TITLE
fix(chile_compra_api_releases): use https instead of http

### DIFF
--- a/kingfisher_scrapy/spiders/chile_compra_api_base.py
+++ b/kingfisher_scrapy/spiders/chile_compra_api_base.py
@@ -8,10 +8,6 @@ from kingfisher_scrapy.util import components, handle_http_error
 
 
 class ChileCompraAPIBase(IndexSpider, PeriodicSpider):
-    custom_settings = {
-        "DOWNLOAD_FAIL_ON_DATALOSS": False,
-    }
-
     # BaseSpider
     date_format = "year-month"
     # They have data since 2009, but the API is too slow to download them all
@@ -26,7 +22,7 @@ class ChileCompraAPIBase(IndexSpider, PeriodicSpider):
 
     # IndexSpider
     result_count_pointer = "/pagination/total"
-    limit = 10
+    limit = 1000
     parse_list_callback = "parse_page"
 
     # Local

--- a/kingfisher_scrapy/spiders/chile_compra_api_releases.py
+++ b/kingfisher_scrapy/spiders/chile_compra_api_releases.py
@@ -33,4 +33,5 @@ class ChileCompraAPIReleases(ChileCompraAPIBase):
     def handle_item(self, item):
         for key in item:
             if key.startswith("url"):
-                yield self.build_request(item[key], formatter=components(-2))
+                # The API returns URLs with HTTP, which raises timeouts
+                yield self.build_request(item[key].replace("http", "https"), formatter=components(-2))


### PR DESCRIPTION
Turns out the issue was that the URL list endpoint was returning HTTP links instead of HTTPS ones, and HTTP times out.
closes #1198 