### PR TITLE
fix(united_kingdom_fts): use PeriodicSpider, step=1 to retrieve all releases

### DIFF
--- a/kingfisher_scrapy/spiders/united_kingdom_fts.py
+++ b/kingfisher_scrapy/spiders/united_kingdom_fts.py
@@ -34,10 +34,10 @@ class UnitedKingdomFTS(LinksSpider, PeriodicSpider):
 
     # PeriodicSpider
     pattern = (
-        "https://www.find-tender.service.gov.uk/api/1.0/ocdsReleasePackages?updatedFrom={"
-        "0:%Y-%m-%dT%H:%M:%SZ}&updatedTo={1:%Y-%m-%dT%H:%M:%SZ}"
+        "https://www.find-tender.service.gov.uk/api/1.0/ocdsReleasePackages?updatedFrom="
+        "{0:%Y-%m-%dT%H:%M:%SZ}&updatedTo={1:%Y-%m-%dT%H:%M:%SZ}"
     )
-    # The endpoint doesn't return all the available releases with longer time frames
+    # The endpoint doesn't return all available releases with a longer `step` value.
     step = 1
 
     @handle_http_error


### PR DESCRIPTION
closes #1203 

The endpoint misses some releases if the time frame (and pagination) is longer