### PR TITLE
feat: add argentina_buenos_aires, handle multiple CSV files in pipeline

### DIFF
--- a/kingfisher_scrapy/base_spiders/base_spider.py
+++ b/kingfisher_scrapy/base_spiders/base_spider.py
@@ -66,6 +66,7 @@ class BaseSpider(scrapy.Spider):
     root_path = ""
     resize_package = False
     unflatten = False
+    unflatten_combine = False
     unflatten_args = {}
     ocds_version = "1.1"
 

--- a/kingfisher_scrapy/pipelines.py
+++ b/kingfisher_scrapy/pipelines.py
@@ -14,6 +14,7 @@ from flattentool.exceptions import FlattenToolWarning
 from scrapy.exceptions import DropItem, NotSupported
 from scrapy.utils.defer import deferred_from_coro
 
+from kingfisher_scrapy.exceptions import IncoherentConfigurationError
 from kingfisher_scrapy.items import File, FileItem, PluckedItem
 from kingfisher_scrapy.util import transcode
 
@@ -130,11 +131,29 @@ class Pluck(BasePipeline):
 
 
 class Unflatten(BasePipeline):
-    """Converts an item's data from CSV/XLSX to JSON, using the ``unflatten`` command from Flatten Tool."""
+    """
+    Converts an item's data from CSV/XLSX to JSON, using the ``unflatten`` command from Flatten Tool.
+
+    If the spider sets ``unflatten_combine = True``, all CSV items are accumulated into a single temporary directory
+    and unflattened together as one combined release package. The spider must set ``self._csv_total`` (the number of
+    CSV files to expect) before any items flow through the pipeline — typically in ``parse_list``.
+    Intermediate items are dropped; only the final combined item is emitted.
+    """
+
+    def __init__(self, crawler):
+        super().__init__(crawler)
+        if self.spider.unflatten_combine and not self.spider.unflatten:
+            raise IncoherentConfigurationError("unflatten_combine = True requires unflatten = True.")
+        if self.spider.unflatten_combine:
+            self._combine_tmpdir = tempfile.TemporaryDirectory()
+            self._combine_count = 0
 
     def process_item(self, item):
         if not self.spider.unflatten or not isinstance(item, File | FileItem):
             return item
+
+        if self.spider.unflatten_combine:
+            return self._process_combined(item)
 
         input_name = item.file_name
 
@@ -173,9 +192,7 @@ class Unflatten(BasePipeline):
                     input_name,
                     root_list_path="releases",
                     root_id="ocid",
-                    schema=jsonref.loads(
-                        pkgutil.get_data("kingfisher_scrapy", f"schema/{self.spider.ocds_version}.json")
-                    ),
+                    schema=self._get_schema(),
                     input_format=input_format,
                     output_name=output_name,
                     **self.spider.unflatten_args,
@@ -185,6 +202,51 @@ class Unflatten(BasePipeline):
                 item.data = f.read()
 
         return item
+
+    def _get_schema(self):
+        if not hasattr(self, "_schema"):
+            self._schema = jsonref.loads(
+                pkgutil.get_data("kingfisher_scrapy", f"schema/{self.spider.ocds_version}.json")
+            )
+        return self._schema
+
+    def _process_combined(self, item):
+        combine_dir = self._combine_tmpdir.name
+
+        if item.data:
+            with open(os.path.join(combine_dir, item.file_name), "wb") as f:
+                f.write(item.data)
+
+        self._combine_count += 1
+        if self._combine_count < self.spider.csv_total:
+            raise DropItem(f"Buffering for combined unflatten ({self._combine_count}/{self.spider.csv_total})")
+
+        if not any(f.endswith(".csv") for f in os.listdir(combine_dir)):
+            raise DropItem("All CSV downloads failed; nothing to unflatten")
+
+        output_name = os.path.join(combine_dir, "result.json")
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FlattenToolWarning)
+            unflatten(
+                combine_dir,
+                root_list_path="releases",
+                root_id="ocid",
+                schema=self._get_schema(),
+                input_format="csv",
+                output_name=output_name,
+                **self.spider.unflatten_args,
+            )
+
+        with open(output_name, "rb") as f:
+            item.data = f.read()
+        item.file_name = "result.json"
+
+        return item
+
+    def close_spider(self):
+        if self.spider.unflatten_combine:
+            self._combine_tmpdir.cleanup()
 
 
 def _resolve_pointer(data, pointer):

--- a/kingfisher_scrapy/spiders/argentina_buenos_aires.py
+++ b/kingfisher_scrapy/spiders/argentina_buenos_aires.py
@@ -1,0 +1,42 @@
+from kingfisher_scrapy.base_spiders import CKANSpider, SimpleSpider
+from kingfisher_scrapy.util import BROWSER_USER_AGENT, MAX_DOWNLOAD_TIMEOUT, components
+
+
+class ArgentinaBuenosAires(CKANSpider, SimpleSpider):
+    """
+    Domain
+      Ciudad de Buenos Aires
+    API documentation
+      https://data.buenosaires.gob.ar/acerca/ckan
+    Bulk download documentation
+      https://data.buenosaires.gob.ar/dataset/buenos-aires-compras
+    """
+
+    name = "argentina_buenos_aires"
+    custom_settings = {
+        "DOWNLOAD_TIMEOUT": MAX_DOWNLOAD_TIMEOUT,
+        "USER_AGENT": BROWSER_USER_AGENT,
+    }
+
+    # BaseSpider
+    unflatten = True
+    unflatten_combine = True
+
+    # SimpleSpider
+    data_type = "release_package"
+
+    # CKANSpider
+    ckan_api_url = "https://data.buenosaires.gob.ar"
+    ckan_package_id = "buenos-aires-compras"
+    ckan_resource_format = "CSV"
+    formatter = staticmethod(components(-1))
+
+    def parse_list(self, response):
+        requests = list(super().parse_list(response))
+        # Filter bac_anual.csv and bac.csv as they are covered by other files
+        self.csv_total = len(requests) - 2
+        for request in requests:
+            if components(-1)(request.url) in ("bac_anual.csv", "bac.csv"):
+                continue
+            else:
+                yield request


### PR DESCRIPTION
This was the implementation by Claude (with some review from my side)
But I don't think we can merge this because the CSV files are large, and the flatten tool consumed>60% of the available memory on the server when I tried it. I've killed the spider before it finished because the memory was getting higher and higher.

ref #1202 